### PR TITLE
Configures automatic deployments to a staging environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,10 @@ jobs:
     steps:
       - checkout
 
+      - run:
+          name: Setup Heroku
+          command: bash .circleci/setup-heroku.sh
+
       - restore_cache:
           keys:
             - gems-{{ checksum "Gemfile.lock" }}
@@ -20,4 +24,8 @@ jobs:
           key: gems-{{ checksum "Gemfile.lock" }}
 
       - run: bundle exec jekyll build
+
+      - run:
+          name: Deploy to Heroku
+          command: git push heroku ${CIRCLE_BRANCH}:master -f
 

--- a/.circleci/setup-heroku.sh
+++ b/.circleci/setup-heroku.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -eo pipefail
+git remote add heroku https://git.heroku.com/vanilla-project-staging.git
+wget https://cli-assets.heroku.com/branches/stable/heroku-linux-amd64.tar.gz
+tar -xzf heroku-linux-amd64.tar.gz
+
+cat > ~/.netrc << EOF
+machine api.heroku.com
+  login $HEROKU_LOGIN
+  password $HEROKU_API_KEY
+machine git.heroku.com
+  login $HEROKU_LOGIN
+  password $HEROKU_API_KEY
+EOF
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,10 @@
 source "https://rubygems.org"
 ruby RUBY_VERSION
 
+gem "rake", "12.0.0"
+gem "puma", "3.9.1"
 gem "jekyll", "3.4.3"
+gem "rack-jekyll", "0.5.0"
 
 group :jekyll_plugins do
    gem "jekyll-feed", "~> 0.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,13 @@ GEM
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
+    puma (3.9.1)
+    rack (1.6.8)
+    rack-jekyll (0.5.0)
+      jekyll (>= 1.3)
+      listen (>= 1.3)
+      rack (~> 1.5)
+    rake (12.0.0)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
@@ -45,7 +52,13 @@ PLATFORMS
 DEPENDENCIES
   jekyll (= 3.4.3)
   jekyll-feed (~> 0.6)
+  puma (= 3.9.1)
+  rack-jekyll (= 0.5.0)
+  rake (= 12.0.0)
   tzinfo-data
 
+RUBY VERSION
+   ruby 2.2.1p85
+
 BUNDLED WITH
-   1.11.2
+   1.15.0

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -t 8:32 -w 3 -p $PORT

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+namespace :assets do
+  task :precompile do
+    puts `bundle exec jekyll build`
+  end
+end

--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,7 @@ markdown: kramdown
 gems:
   - jekyll-feed
 exclude:
+  - vendor
   - contributing.md
   - Gemfile
   - Gemfile.lock

--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,6 @@ permalink: pretty
 collections:
   guides:
     output: true
-    permalink: /:path
 
 defaults:
   - scope:

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,2 @@
+require 'rack/jekyll'
+run Rack::Jekyll.new


### PR DESCRIPTION
Sets up automatic deployments to Heroku (https://vanilla-project-staging.herokuapp.com).
At the moment it is set up in a way that _all_ PRs will deploy into that dyno once the branch passes CI.
Which makes it a bit useless once we have more than one PR open as the last one will always override whatever was deployed before.

But luckily Heroku has a feature called [review apps](https://devcenter.heroku.com/articles/github-integration-review-apps).
This will automatically create a temporary app for every PR that is open.

You can see that integration with GitHub below already where it says _&ldquo;christophgockel temporarily deployed to vanilla-project-staging-pr-15&rdquo;_, together with a link to the freshly deployed app. 👍 